### PR TITLE
Feature/request arguments

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -67,6 +67,35 @@ class AbstractController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControl
 	 */
 	protected $accessControlService;
 
+	/**
+	 * Request Arguments
+	 * @var \array
+	 */
+	protected $requestArguments = NULL;
+
+	/*
+	 * Referrer Arguments
+	 * @var \array
+	 */
+	protected $referrerArguments = NULL;
+
+	/**
+	 * Initialize Action
+	 */
+	public function initializeAction() {
+		$originalRequestArguments = $this->request->getArguments();
+		$action = $originalRequestArguments['action'];
+		unset($originalRequestArguments['action']);
+		unset($originalRequestArguments['controller']);
+
+		$this->requestArguments = array(
+			'action' => $action ,
+			'pluginName' => $this->request->getPluginName(),
+			'controllerName' => $this->request->getControllerName(),
+			'extensionName' => $this->request->getControllerExtensionName(),
+			'arguments' => $originalRequestArguments,
+		);
+	}
 
 	/**
 	 * Upload file

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -95,6 +95,12 @@ class AbstractController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControl
 			'extensionName' => $this->request->getControllerExtensionName(),
 			'arguments' => $originalRequestArguments,
 		);
+		if($this->request->hasArgument('referrerArguments') AND
+			is_array($this->request->getArgument('referrerArguments'))) {
+		    $this->referrerArguments = $this->request->getArgument('referrerArguments');
+		} else {
+		    $this->referrerArguments = NULL;
+		}
 	}
 
 	/**

--- a/Classes/Controller/PositionController.php
+++ b/Classes/Controller/PositionController.php
@@ -64,6 +64,7 @@ class PositionController extends AbstractController {
 	 *
 	 */
 	 public function initializeAction() {
+		parent::initializeAction();
 		$this->organizationRepository->setDefaultOrderings(array('title' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_ASCENDING));
 		if ($this->arguments->hasArgument('position')) {
 			$this->arguments->getArgument('position')
@@ -117,7 +118,12 @@ class PositionController extends AbstractController {
 	 * @return void
 	 */
 	public function showAction(\Webfox\Placements\Domain\Model\Position $position) {
-		$this->view->assign('position', $position);
+		$this->view->assignMultiple(
+			array(
+				'position' => $position,
+				'requestArguments' => $this->requestArguments
+			)
+		);
 	}
 
 	/**
@@ -357,6 +363,7 @@ class PositionController extends AbstractController {
 				'positions' => $positions,
 				'search' => $search,
 				'demand' => $demand,
+				'requestArguments' => $this->requestArguments,
 			)
 		);
 	}

--- a/Resources/Private/Partials/Position/List/Item.html
+++ b/Resources/Private/Partials/Position/List/Item.html
@@ -1,5 +1,7 @@
 {namespace ps=Webfox\Placements\ViewHelpers}
-<f:debug title="requestArguments">{requestArguments}</f:debug>
+<f:if condition="{settings.debug}">
+	<f:debug title="requestArguments">{requestArguments}</f:debug>
+</f:if>
 <div class="row-fluid list-item">
 <f:comment>titel, organization.title,entryDate,organization.zip organization.city</f:comment>
 	<div class="span4 title">
@@ -7,7 +9,7 @@
 			action="show"
 			pageUid="{settings.detailPid}" 
 			arguments="{position : position,
-						referrerArguments: requestArguments}"
+					referrerArguments: requestArguments}"
 		>
 				{position.title}
 		</f:link.action>
@@ -23,7 +25,8 @@
 			<f:link.action 
 				action="show"
 				pageUid="{settings.detailPid}" 
-				arguments="{position : position}"
+				arguments="{position : position,
+					referrerArguments: requestArguments}"
 				class="btn"
 				title="{position.title}"
 			>
@@ -33,7 +36,8 @@
 				<f:link.action 
 					pageUid="{settings.detailPid}" 
 					action="edit" 
-					arguments="{position: position}" 
+					arguments="{position : position,
+						referrerArguments: requestArguments}"
 					class="btn edit" 
 					title="{f:translate(key:'tx_placements.general.edit', default: 'Edit')}"
 				><i class="fa fa-pencil-square-o"></i></f:link.action>

--- a/Resources/Private/Partials/Position/List/Item.html
+++ b/Resources/Private/Partials/Position/List/Item.html
@@ -1,12 +1,13 @@
 {namespace ps=Webfox\Placements\ViewHelpers}
-
+<f:debug title="requestArguments">{requestArguments}</f:debug>
 <div class="row-fluid list-item">
 <f:comment>titel, organization.title,entryDate,organization.zip organization.city</f:comment>
 	<div class="span4 title">
 		<f:link.action 
 			action="show"
 			pageUid="{settings.detailPid}" 
-			arguments="{position : position}"
+			arguments="{position : position,
+						referrerArguments: requestArguments}"
 		>
 				{position.title}
 		</f:link.action>

--- a/Resources/Private/Templates/Position/List.html
+++ b/Resources/Private/Templates/Position/List.html
@@ -24,7 +24,12 @@ This Template creates a list of positions.
 				pagesAfter: '{settings.position.list.paginate.pagesAfter}'
 				}" >
 		<f:for each="{paginatedPositions}" as="position">
-			<f:render partial="Position/List/Item" arguments="{position: '{position}', settings: '{settings}'}" /> 
+			<f:render 
+				partial="Position/List/Item" 
+				arguments="{position: '{position}', 
+							settings: '{settings}', 
+							requestArguments: '{requestArguments}'}" 
+			/> 
 		</f:for>
 	</pw:paginate>
 </div>

--- a/Resources/Private/Templates/Position/List.html
+++ b/Resources/Private/Templates/Position/List.html
@@ -8,9 +8,9 @@ This Template creates a list of positions.
 <f:if condition="{settings.debug}">
 	<f:debug title="settings">{settings}</f:debug>
 </f:if>
-<f:flashMessages class="message"/>
 
 <div  class="position-list" >
+	<f:flashMessages class="message"/>
 	<f:render partial="Position/List/Head" />
 	<pw:paginate  
 		objects="{positions}" 

--- a/Resources/Private/Templates/Position/SearchResult.html
+++ b/Resources/Private/Templates/Position/SearchResult.html
@@ -8,6 +8,7 @@
 		<f:debug title="Search">{search}</f:debug>
 		<f:debug title="Positions">{positions}</f:debug>
 	</f:if>
+	<f:debug title="request arguments">{requestArguments}</f:debug>
 	<div class="tx-placements search-result">
 		<f:flashMessages class="message" />
 		<f:if condition="{search}">
@@ -27,7 +28,11 @@
 						}"
 					>
 					<f:for each="{paginatedPositions}" as="position">
-						<f:render partial="Position/List/Item" arguments="{position: '{position}', settings: '{settings}'}" /> 
+						<f:render 
+							partial="Position/List/Item" 
+							arguments="{position: '{position}', 
+										settings: '{settings}',
+										requestArguments: '{requestArguments}'}" /> 
 					</f:for>
 					</pw:paginate>
 				</div>

--- a/Resources/Private/Templates/Position/SearchResult.html
+++ b/Resources/Private/Templates/Position/SearchResult.html
@@ -7,8 +7,8 @@
 		<f:debug title="Demand">{demand}</f:debug>
 		<f:debug title="Search">{search}</f:debug>
 		<f:debug title="Positions">{positions}</f:debug>
+		<f:debug title="request arguments">{requestArguments}</f:debug>
 	</f:if>
-	<f:debug title="request arguments">{requestArguments}</f:debug>
 	<div class="tx-placements search-result">
 		<f:flashMessages class="message" />
 		<f:if condition="{search}">
@@ -27,13 +27,13 @@
 							pagesAfter: '{settings.position.list.paginate.pagesAfter}'
 						}"
 					>
-					<f:for each="{paginatedPositions}" as="position">
-						<f:render 
-							partial="Position/List/Item" 
-							arguments="{position: '{position}', 
-										settings: '{settings}',
-										requestArguments: '{requestArguments}'}" /> 
-					</f:for>
+						<f:for each="{paginatedPositions}" as="position">
+							<f:render 
+								partial="Position/List/Item" 
+								arguments="{position: '{position}', 
+											settings: '{settings}',
+											requestArguments: '{requestArguments}'}" /> 
+						</f:for>
 					</pw:paginate>
 				</div>
 			</f:if>

--- a/Resources/Private/Templates/Position/Show.html
+++ b/Resources/Private/Templates/Position/Show.html
@@ -4,6 +4,7 @@ This Template displays a single position.
 <f:section name="main">
 <f:if condition="{settings.debug}">
 	<f:debug title="settings">{settings}</f:debug>
+	<f:debug title="request arguments">{requestArguments}</f:debug>
 </f:if>
 	<div class="position-detail">
 		<f:flashMessages class="message"/>

--- a/Resources/Private/Templates/Position/Show.html
+++ b/Resources/Private/Templates/Position/Show.html
@@ -5,6 +5,7 @@ This Template displays a single position.
 <f:if condition="{settings.debug}">
 	<f:debug title="settings">{settings}</f:debug>
 	<f:debug title="request arguments">{requestArguments}</f:debug>
+	<f:debug title="referrerArguments">{referrerArguments}</f:debug>
 </f:if>
 	<div class="position-detail">
 		<f:flashMessages class="message"/>
@@ -19,11 +20,30 @@ This Template displays a single position.
 		</div>
 		<div class="row-fluid">
 			<div class="span12">
-				<f:link.action 
-					action="list"
-					pageUid="{settings.backPid}" 
-					title="{f:translate(key:'tx_placements.general.backToList')}"
-					class="btn back pull-right"><i class="fa fa-times"></i>&nbsp;{f:translate(key:'tx_placements.general.backToList')}</f:link.action>
+				<f:if condition="{referrerArguments}">
+					<f:then>
+						<f:link.action 
+							action="{referrerArguments.action}"
+							pageUid="{settings.backPid}" 
+							title="{f:translate(key:'tx_placements.general.backToList')}"
+							class="btn back pull-right"
+							arguments="{
+									overwriteDemand: '{referrerArguments.arguments.overwriteDemand}',
+									search: '{referrerArguments.arguments.search}'}"
+						>
+							<i class="fa fa-times"></i>&nbsp;{f:translate(key:'tx_placements.general.backToList')}
+						</f:link.action>
+					</f:then>
+					<f:else>
+						<f:link.action
+							action="list"
+							pageUid="{settings.backPid}"
+							class="btn back pull-right"
+						>
+							<i class="fa fa-times"></i>&nbsp;{f:translate(key:'tx_placements.general.backToList')}
+						</f:link.action>
+					</f:else>
+				</f:if>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
A Controller now keeps its current request arguments and its referrers request arguments. 
Thus the view can pass this arguments to another view, which in turn can decide to render a back link with the referrer arguments. 
Currently we use it to get back to a filtered list view or search result view from the show view of positions.

Unfortunatly we ar not able to restore the current page of the pagination widget. The widget controller works with an internal argument @widget_<number of widget> which we can not pass back due of the at sign.
